### PR TITLE
Programa 2026

### DIFF
--- a/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
+++ b/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
@@ -36,10 +36,16 @@ Para aquellos interesados en participar, el precio de inscripción será gratuit
 
 Para formalizar la inscripción, los interesados podrán enviar un correo electrónico a <FontBold className='text-secondary'><a href='mailto:carlosangel1972@hotmail.com'>carlosangel1972@hotmail.com</a></FontBold>. También habrá opción de inscribirse de forma presencial hasta 15 minutos antes del inicio de la salida de cada categoría.
 
-
 <figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
-	<a href='https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif' target='_blank' rel='noopener noreferrer'>
-		<img src='https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif' alt='cartel-carrera' class='rounded max-w-auto mt-14' />
+	<a
+		href='https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif'
+		target='_blank'
+		rel='noopener noreferrer'
+	>
+		<img
+			src='https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif'
+			alt='cartel-carrera'
+			class='rounded max-w-auto mt-14'
+		/>
 	</a>
 </figure>
-

--- a/src/content/blog/programa-san-lorenzo-2026.mdx
+++ b/src/content/blog/programa-san-lorenzo-2026.mdx
@@ -51,6 +51,21 @@ import Program from '../../components/Program.astro'
 				]
 			},
 			{
+				title: 'Miércoles 4 de agosto de 2026',
+				event: [
+					{
+						title: 'II Torneo de Pádel Infantil San Lorenzo — Partidos finalistas',
+						time: 'A confirmar',
+						description:
+							'Inscripciones del 15 al 25 de julio en el teléfono <a class="text-primary" href="tel:677218810">677 218 810</a>. Participantes: niñ@s nacid@s entre 2012 y 2016. Precio: 10 € por pareja.',
+						location: 'Parque D. Ramón Fernández Urrutia',
+						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1784885704/744198930_1412458857416199_6590324517587223857_n_p4pz0o.avif'
+					}
+				]
+			},
+			{
 				title: 'Miércoles 5 de agosto de 2026',
 				event: [
 					{
@@ -68,13 +83,13 @@ import Program from '../../components/Program.astro'
 				event: [
 					{
 						title: 'III Torneo 3x3 San Lorenzo',
-						time: '18:30',
+						time: '18:00',
 						description:
-							'Categorías: Infantil Mixto (2013–2014), Cadete (2011–2012) y Junior (2009–2010).<br/><br/>Inscripción hasta el 6 de agosto, en <a class="text-primary" href="mailto:vecinosalamedadecervera@gmail.com">vecinosalamedadecervera@gmail.com</a> indicando: nombre y fecha de nacimiento de los jugadores y el nombre del equipo y la categoría',
+							'Categorías: Infantil Mixto (2013–2014), Cadete (2011–2012) y Junior (2009–2010).<br/><br/>Inscripción hasta el 6 de agosto, en <a class="text-primary" href="mailto:vecinosalamedadecervera@gmail.com">vecinosalamedadecervera@gmail.com</a>',
 						location: 'Parque D. Ramón Fernández Urrutia',
 						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
 						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753865720/cartel-baloncesto.-1_qvfxjr.webp'
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1784885704/749301494_1411904790804939_2894369859791087328_n_itiu58.avif'
 					}
 				]
 			},
@@ -104,16 +119,6 @@ import Program from '../../components/Program.astro'
 						time: '19:30',
 						location: 'Salón de Actos',
 						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
-					},
-					{
-						title: 'II Torneo de Pádel Infantil San Lorenzo — Partidos finalistas',
-						time: 'A confirmar',
-						description:
-							'Inscripciones del 15 al 25 de julio en el teléfono <a class="text-primary" href="tel:677218810">677 218 810</a>. Participantes: niñ@s nacid@s entre 2012 y 2016. Precio: 10 € por pareja.',
-						location: 'Parque D. Ramón Fernández Urrutia',
-						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
-						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753865511/padel-2025_awcd5c.webp'
 					},
 					{
 						title: 'Disco móvil amenizada por Marcos Galván',

--- a/src/content/blog/programa-san-lorenzo-2026.mdx
+++ b/src/content/blog/programa-san-lorenzo-2026.mdx
@@ -36,21 +36,6 @@ import Program from '../../components/Program.astro'
 				]
 			},
 			{
-				title: 'Domingo 2 de agosto de 2026',
-				event: [
-					{
-						title: 'XI Milla Urbana y IX Legua popular "Alameda de Cervera"',
-						time: '10:00',
-						description:
-							'Categorías Milla Urbana: Benjamín, Alevín, Infantil, Cadete, Junior, Absoluta y Veteranos. <br/><br/>Categorías Legua Pedrestre: Cadete, Junior, Absoluta y Veteranos.<br/><br/> Inscripción gratuita para Benjamín, Alevín e Infantil. 3 € para el resto de categorías de la Milla. Inscripción para Milla+Legua 8 €',
-						location: 'Calle Cervantes',
-						map: 'https://maps.app.goo.gl/JDWn5PFm6c8vc2mdA',
-						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753865890/milla-urbana-legua-pedrestre-2025_jiuckz.webp'
-					}
-				]
-			},
-			{
 				title: 'Miércoles 4 de agosto de 2026',
 				event: [
 					{
@@ -131,6 +116,16 @@ import Program from '../../components/Program.astro'
 			{
 				title: 'Domingo 9 de agosto de 2026',
 				event: [
+		 {
+						title: 'XI Milla Urbana y IX Legua popular "Alameda de Cervera"',
+						time: '10:00',
+						description:
+							'Categorías Milla Urbana: Benjamín, Alevín, Infantil, Cadete, Junior, Absoluta y Veteranos. <br/><br/>Categorías Legua Pedrestre: Cadete, Junior, Absoluta y Veteranos.<br/><br/> Inscripción gratuita para Benjamín, Alevín e Infantil. 2 € para el resto de categorías de la Milla y 3 € para la Milla.',
+						location: 'Calle Cervantes',
+						map: 'https://maps.app.goo.gl/JDWn5PFm6c8vc2mdA',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif'
+					},
 					{
 						title: 'Concurso infantil de pintura, edad máxima 12 años incluido',
 						time: '11:00',

--- a/src/content/blog/programa-san-lorenzo-2026.mdx
+++ b/src/content/blog/programa-san-lorenzo-2026.mdx
@@ -3,7 +3,7 @@ title: 'Programa San Lorenzo 2026'
 description: 'Programa de fiestas de San Lorenzo 2026 en Alameda de Cervera.'
 date: '24 Jul 2026'
 pubDate: '2026-07-24'
-image: 'https://res.cloudinary.com/daid7iwrd/image/upload/v1753965589/526648521_122165033930439777_5615925026356010013_n_kemrpx_qhdadi.avif'
+image: 'https://res.cloudinary.com/daid7iwrd/image/upload/q_auto/f_auto/v1721240236/images/news/974d8133003123354a2950bdb6465d04.webp'
 ---
 
 import Program from '../../components/Program.astro'

--- a/src/content/blog/programa-san-lorenzo-2026.mdx
+++ b/src/content/blog/programa-san-lorenzo-2026.mdx
@@ -1,0 +1,237 @@
+---
+title: 'Programa San Lorenzo 2026'
+description: 'Programa de fiestas de San Lorenzo 2026 en Alameda de Cervera.'
+date: '24 Jul 2026'
+pubDate: '2026-07-24'
+image: 'https://res.cloudinary.com/daid7iwrd/image/upload/v1753965589/526648521_122165033930439777_5615925026356010013_n_kemrpx_qhdadi.avif'
+---
+
+import Program from '../../components/Program.astro'
+
+<Program
+	program={{
+		days: [
+			{
+				title: 'Sábado 1 de agosto de 2026',
+				event: [
+					{
+						title: 'III Torneo de Pádel San Lorenzo',
+						time: '20:00',
+						description:
+							'Inscripciones en el número de teléfono <a class="text-primary" href="tel:685154410">685 154 410</a>. Partidos clasificatorios los días 1 y 2 de agosto. Semifinal y final los días 8 y 9 de agosto. Se empezará sobre las 8 de la tarde. Coste por pareja: 20 €.',
+						location: 'Parque D. Ramón Fernández Urrutia',
+						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1784885704/749119750_1411684414160310_2439858722489362056_n_mexrcn.avif'
+					},
+					{
+						title: 'Novena a San Lorenzo',
+						time: '21:00',
+						description: 'Todos los días del 1 al 9 de agosto',
+						location: 'Parroquia de San Lorenzo',
+						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753965589/526648521_122165033930439777_5615925026356010013_n_kemrpx_qhdadi.avif'
+					}
+				]
+			},
+			{
+				title: 'Domingo 2 de agosto de 2026',
+				event: [
+					{
+						title: 'XI Milla Urbana y IX Legua popular "Alameda de Cervera"',
+						time: '10:00',
+						description:
+							'Categorías Milla Urbana: Benjamín, Alevín, Infantil, Cadete, Junior, Absoluta y Veteranos. <br/><br/>Categorías Legua Pedrestre: Cadete, Junior, Absoluta y Veteranos.<br/><br/> Inscripción gratuita para Benjamín, Alevín e Infantil. 3 € para el resto de categorías de la Milla. Inscripción para Milla+Legua 8 €',
+						location: 'Calle Cervantes',
+						map: 'https://maps.app.goo.gl/JDWn5PFm6c8vc2mdA',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753865890/milla-urbana-legua-pedrestre-2025_jiuckz.webp'
+					}
+				]
+			},
+			{
+				title: 'Miércoles 5 de agosto de 2026',
+				event: [
+					{
+						title: 'Juegos y Gymkana acuática',
+						time: '11:00',
+						location: 'Piscina Municipal',
+						map: 'https://maps.app.goo.gl/3EEq3aDJdar4XBW36',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753965373/526745915_18006132239789388_539911353885936848_n_szivdb.webp'
+					}
+				]
+			},
+			{
+				title: 'Viernes 7 de agosto de 2026',
+				event: [
+					{
+						title: 'III Torneo 3x3 San Lorenzo',
+						time: '18:30',
+						description:
+							'Categorías: Infantil Mixto (2013–2014), Cadete (2011–2012) y Junior (2009–2010).<br/><br/>Inscripción hasta el 6 de agosto, en <a class="text-primary" href="mailto:vecinosalamedadecervera@gmail.com">vecinosalamedadecervera@gmail.com</a> indicando: nombre y fecha de nacimiento de los jugadores y el nombre del equipo y la categoría',
+						location: 'Parque D. Ramón Fernández Urrutia',
+						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753865720/cartel-baloncesto.-1_qvfxjr.webp'
+					}
+				]
+			},
+			{
+				title: 'Sábado 8 de agosto de 2026',
+				event: [
+					{
+						title: 'Sellado de tablillas XXIII Concurso PAL Gran Prior',
+						time: '09:00 - 15:00',
+						description:
+							'A las 9 de la mañana arrancará el concurso de pintura al aire libre "Gran Prior". Los artistas podrán sellar sus tablillas en el salón de actos, entre el parque, D. Juan de Villanueva y Bar José Ángel.<br/><br/> Hasta la entrega de obras se podrá encontrar a los artistas pintando por las calles de Alameda de Cervera, en sitios como el Puente Gran Prior, Puente Vado Lancero, Castillo de Cervera, la Cooperativa, Parroquia de San Lorenzo y también en Villacentenos.',
+						location: 'Salón de Actos',
+						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753866371/xxii-pal_cofgfg.webp'
+					},
+					{
+						title: 'Entrega de tablillas y cuadros XXIII Concurso PAL Gran Prior',
+						time: '19:00',
+						description:
+							'Se hará entrega de las obras, hasta la 19:15, en el Salón de Actos, donde serán expuestas para todo aquel que quiera disfrutar de ellas.',
+						location: 'Salón de Actos',
+						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
+					},
+					{
+						title: 'Entrega de premios del XXIII Concurso PAL Gran Prior',
+						time: '19:30',
+						location: 'Salón de Actos',
+						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
+					},
+					{
+						title: 'II Torneo de Pádel Infantil San Lorenzo — Partidos finalistas',
+						time: 'A confirmar',
+						description:
+							'Inscripciones del 15 al 25 de julio en el teléfono <a class="text-primary" href="tel:677218810">677 218 810</a>. Participantes: niñ@s nacid@s entre 2012 y 2016. Precio: 10 € por pareja.',
+						location: 'Parque D. Ramón Fernández Urrutia',
+						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
+						image:
+							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753865511/padel-2025_awcd5c.webp'
+					},
+					{
+						title: 'Disco móvil amenizada por Marcos Galván',
+						time: '23:00',
+						location: 'Corral del Ayuntamiento',
+						map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+					}
+				]
+			},
+			{
+				title: 'Domingo 9 de agosto de 2026',
+				event: [
+					{
+						title: 'Concurso infantil de pintura, edad máxima 12 años incluido',
+						time: '11:00',
+						location: 'Salón de Actos',
+						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
+					},
+					{
+						title: 'Juegos infantiles',
+						time: '18:30',
+						description:
+							'Cada participante deberá traer su bicicleta y su saco (Carrera de sacos, cinta, lentitud y 3 pies)',
+						location: 'Parque D. Ramón Fernández Urrutia',
+						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7'
+					},
+					{
+						title: 'Novena a San Lorenzo',
+						time: '21:00',
+						location: 'Parroquia de San Lorenzo',
+						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+					},
+					{
+						title: 'Subasta en honor al patrón',
+						time: '22:30',
+						location: 'Exterior de la Parroquia de San Lorenzo',
+						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+					},
+					{
+						title: 'Fuegos artificiales',
+						time: '00:00',
+						location: 'Corral del Ayuntamiento',
+						map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+					},
+					{
+						title: 'Pregón de las fiestas de San Lorenzo 2026',
+						time: '00:30',
+						location: 'Parque D. Juan de Villanueva',
+						map: 'https://maps.app.goo.gl/62d6CSfmCoafbb6k8'
+					},
+					{
+						title: 'Orquesta',
+						time: 'A continuación',
+						location: 'Parque D. Juan de Villanueva',
+						map: 'https://maps.app.goo.gl/62d6CSfmCoafbb6k8'
+					}
+				]
+			},
+			{
+				title: 'Lunes 10 de agosto de 2026',
+				event: [
+					{
+						title: 'Función religiosa en honor al Santo Patrón',
+						time: '12:30',
+						location: 'Parroquia de San Lorenzo',
+						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+					},
+					{
+						title: 'Suelta de vaquillas',
+						time: '18:00',
+						location: 'Corral del Ayuntamiento',
+						map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+					},
+					{
+						title: 'Procesión en honor a San Lorenzo',
+						time: '21:30',
+						location: 'Parroquia de San Lorenzo',
+						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+					},
+					{
+						title: 'Verbena',
+						time: '23:30',
+						location: 'Parque D. Juan de Villanueva',
+						map: 'https://maps.app.goo.gl/62d6CSfmCoafbb6k8'
+					}
+				]
+			},
+			{
+				title: 'Martes 11 de agosto de 2026',
+				event: [
+					{
+						title: 'Misa de difuntos',
+						time: '11:00',
+						location: 'Parroquia de San Lorenzo',
+						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+					},
+					{
+						title: 'Cata de vinos y quesos',
+						time: '12:00',
+						location: 'Cooperativa San Lorenzo',
+						description: 'Organiza Coop. San Lorenzo y D.O. La Mancha.',
+						map: 'https://maps.app.goo.gl/JwvFF2HDJJN1D6tB7'
+					},
+					{
+						title: 'Comida de hermandad',
+						time: '15:00',
+						location: 'Parque D. Ramón Fernández Urrutia',
+						description: 'A 2,50 €/ración',
+						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7'
+					},
+					{
+						title: 'Disco móvil',
+						time: '23:00',
+						location: 'Parque D. Juan de Villanueva',
+						map: 'https://maps.app.goo.gl/62d6CSfmCoafbb6k8'
+					}
+				]
+			}
+		]
+	}}
+/>

--- a/src/content/blog/programa-san-lorenzo-2026.mdx
+++ b/src/content/blog/programa-san-lorenzo-2026.mdx
@@ -15,51 +15,11 @@ import Program from '../../components/Program.astro'
 				title: 'Sábado 1 de agosto de 2026',
 				event: [
 					{
-						title: 'III Torneo de Pádel San Lorenzo',
-						time: '20:00',
-						description:
-							'Inscripciones en el número de teléfono <a class="text-primary" href="tel:685154410">685 154 410</a>. Partidos clasificatorios los días 1 y 2 de agosto. Semifinal y final los días 8 y 9 de agosto. Se empezará sobre las 8 de la tarde. Coste por pareja: 20 €.',
-						location: 'Parque D. Ramón Fernández Urrutia',
-						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
-						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1784885704/749119750_1411684414160310_2439858722489362056_n_mexrcn.avif'
-					},
-					{
 						title: 'Novena a San Lorenzo',
 						time: '21:00',
 						description: 'Todos los días del 1 al 9 de agosto',
 						location: 'Parroquia de San Lorenzo',
 						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA',
-						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753965589/526648521_122165033930439777_5615925026356010013_n_kemrpx_qhdadi.avif'
-					}
-				]
-			},
-			{
-				title: 'Miércoles 4 de agosto de 2026',
-				event: [
-					{
-						title: 'II Torneo de Pádel Infantil San Lorenzo — Partidos finalistas',
-						time: 'A confirmar',
-						description:
-							'Inscripciones del 15 al 25 de julio en el teléfono <a class="text-primary" href="tel:677218810">677 218 810</a>. Participantes: niñ@s nacid@s entre 2012 y 2016. Precio: 10 € por pareja.',
-						location: 'Parque D. Ramón Fernández Urrutia',
-						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
-						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1784885704/744198930_1412458857416199_6590324517587223857_n_p4pz0o.avif'
-					}
-				]
-			},
-			{
-				title: 'Miércoles 5 de agosto de 2026',
-				event: [
-					{
-						title: 'Juegos y Gymkana acuática',
-						time: '11:00',
-						location: 'Piscina Municipal',
-						map: 'https://maps.app.goo.gl/3EEq3aDJdar4XBW36',
-						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753965373/526745915_18006132239789388_539911353885936848_n_szivdb.webp'
 					}
 				]
 			},
@@ -68,170 +28,169 @@ import Program from '../../components/Program.astro'
 				event: [
 					{
 						title: 'III Torneo 3x3 San Lorenzo',
-						time: '18:00',
+						time: '18:30',
 						description:
 							'Categorías: Infantil Mixto (2013–2014), Cadete (2011–2012) y Junior (2009–2010).<br/><br/>Inscripción hasta el 6 de agosto, en <a class="text-primary" href="mailto:vecinosalamedadecervera@gmail.com">vecinosalamedadecervera@gmail.com</a>',
 						location: 'Parque D. Ramón Fernández Urrutia',
 						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7',
 						image:
 							'https://res.cloudinary.com/daid7iwrd/image/upload/v1784885704/749301494_1411904790804939_2894369859791087328_n_itiu58.avif'
-					}
-				]
-			},
-			{
-				title: 'Sábado 8 de agosto de 2026',
-				event: [
+					},
 					{
-						title: 'Sellado de tablillas XXIII Concurso PAL Gran Prior',
-						time: '09:00 - 15:00',
-						description:
-							'A las 9 de la mañana arrancará el concurso de pintura al aire libre "Gran Prior". Los artistas podrán sellar sus tablillas en el salón de actos, entre el parque, D. Juan de Villanueva y Bar José Ángel.<br/><br/> Hasta la entrega de obras se podrá encontrar a los artistas pintando por las calles de Alameda de Cervera, en sitios como el Puente Gran Prior, Puente Vado Lancero, Castillo de Cervera, la Cooperativa, Parroquia de San Lorenzo y también en Villacentenos.',
+						title: 'Grupo de teatro "Alameda" con su obra "HOMENAJE AL SAINTE"',
+						time: '21:30',					
+						description: 'Entrada a 5 € a beneficio de las obras de la parroquia, al terminar habrá cena solidaria.',
 						location: 'Salón de Actos',
 						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9',
-						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1753866371/xxii-pal_cofgfg.webp'
-					},
-					{
-						title: 'Entrega de tablillas y cuadros XXIII Concurso PAL Gran Prior',
-						time: '19:00',
-						description:
-							'Se hará entrega de las obras, hasta la 19:15, en el Salón de Actos, donde serán expuestas para todo aquel que quiera disfrutar de ellas.',
-						location: 'Salón de Actos',
-						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
-					},
-					{
-						title: 'Entrega de premios del XXIII Concurso PAL Gran Prior',
-						time: '19:30',
-						location: 'Salón de Actos',
-						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
-					},
-					{
-						title: 'Disco móvil amenizada por Marcos Galván',
-						time: '23:00',
-						location: 'Corral del Ayuntamiento',
-						map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+						image: 'https://res.cloudinary.com/daid7iwrd/image/upload/v1785604763/762864191_18083308862666310_2833286557671836434_n_bkphgy.avif'
 					}
-				]
-			},
-			{
-				title: 'Domingo 9 de agosto de 2026',
-				event: [
-		 {
-						title: 'XI Milla Urbana y IX Legua popular "Alameda de Cervera"',
-						time: '10:00',
-						description:
-							'Categorías Milla Urbana: Benjamín, Alevín, Infantil, Cadete, Junior, Absoluta y Veteranos. <br/><br/>Categorías Legua Pedrestre: Cadete, Junior, Absoluta y Veteranos.<br/><br/> Inscripción gratuita para Benjamín, Alevín e Infantil. 2 € para el resto de categorías de la Milla y 3 € para la Milla.',
-						location: 'Calle Cervantes',
-						map: 'https://maps.app.goo.gl/JDWn5PFm6c8vc2mdA',
-						image:
-							'https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif'
-					},
-					{
-						title: 'Concurso infantil de pintura, edad máxima 12 años incluido',
-						time: '11:00',
-						location: 'Salón de Actos',
-						map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
-					},
-					{
-						title: 'Juegos infantiles',
-						time: '18:30',
-						description:
-							'Cada participante deberá traer su bicicleta y su saco (Carrera de sacos, cinta, lentitud y 3 pies)',
-						location: 'Parque D. Ramón Fernández Urrutia',
-						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7'
-					},
-					{
-						title: 'Novena a San Lorenzo',
-						time: '21:00',
-						location: 'Parroquia de San Lorenzo',
-						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
-					},
-					{
-						title: 'Subasta en honor al patrón',
-						time: '22:30',
-						location: 'Exterior de la Parroquia de San Lorenzo',
-						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
-					},
-					{
-						title: 'Fuegos artificiales',
-						time: '00:00',
-						location: 'Corral del Ayuntamiento',
-						map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
-					},
-					{
-						title: 'Pregón de las fiestas de San Lorenzo 2026',
-						time: '00:30',
-						location: 'Parque D. Juan de Villanueva',
-						map: 'https://maps.app.goo.gl/62d6CSfmCoafbb6k8'
-					},
-					{
-						title: 'Orquesta',
-						time: 'A continuación',
-						location: 'Parque D. Juan de Villanueva',
-						map: 'https://maps.app.goo.gl/62d6CSfmCoafbb6k8'
-					}
-				]
-			},
-			{
-				title: 'Lunes 10 de agosto de 2026',
-				event: [
-					{
-						title: 'Función religiosa en honor al Santo Patrón',
-						time: '12:30',
-						location: 'Parroquia de San Lorenzo',
-						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
-					},
-					{
-						title: 'Suelta de vaquillas',
-						time: '18:00',
-						location: 'Corral del Ayuntamiento',
-						map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
-					},
-					{
-						title: 'Procesión en honor a San Lorenzo',
-						time: '21:30',
-						location: 'Parroquia de San Lorenzo',
-						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
-					},
-					{
-						title: 'Verbena',
-						time: '23:30',
-						location: 'Parque D. Juan de Villanueva',
-						map: 'https://maps.app.goo.gl/62d6CSfmCoafbb6k8'
-					}
-				]
-			},
-			{
-				title: 'Martes 11 de agosto de 2026',
-				event: [
-					{
-						title: 'Misa de difuntos',
-						time: '11:00',
-						location: 'Parroquia de San Lorenzo',
-						map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
-					},
-					{
-						title: 'Cata de vinos y quesos',
-						time: '12:00',
-						location: 'Cooperativa San Lorenzo',
-						description: 'Organiza Coop. San Lorenzo y D.O. La Mancha.',
-						map: 'https://maps.app.goo.gl/JwvFF2HDJJN1D6tB7'
-					},
-					{
-						title: 'Comida de hermandad',
-						time: '15:00',
-						location: 'Parque D. Ramón Fernández Urrutia',
-						description: 'A 2,50 €/ración',
-						map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7'
-					},
-					{
-						title: 'Disco móvil',
-						time: '23:00',
-						location: 'Parque D. Juan de Villanueva',
-						map: 'https://maps.app.goo.gl/62d6CSfmCoafbb6k8'
-					}
-				]
-			}
-		]
-	}}
+
+    			]
+    		},
+    		{
+    			title: 'Sábado 8 de agosto de 2026',
+    			event: [
+    					{
+    					title: 'Juegos y Gymkana acuática',
+    					time: '11:00',
+    					location: 'Piscina Municipal',
+    					map: 'https://maps.app.goo.gl/3EEq3aDJdar4XBW36'
+    				},
+    				{
+    					title: 'Concurso infantil de pintura, edad máxima 12 años incluido',
+    					time: '13:00',
+    					location: 'Salón de Actos',
+    					map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
+    				},
+    					{
+    					title: 'Juegos infantiles',
+    					time: '19:00',
+    					description:
+    						'Cada participante deberá traer su bicicleta y su saco (Carrera de sacos, cinta, lentitud y 3 pies)',
+    					location: 'Parque D. Ramón Fernández Urrutia',
+    					map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7'
+    				},
+    				{
+    					title: 'Verbena a cargo del grupo "Evento"',
+    					time: '23:00',
+    					location: 'Corral del Ayuntamiento',
+    					map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+    				}
+    			]
+    		},
+    		{
+    			title: 'Domingo 9 de agosto de 2026',
+    			event: [
+    	 {
+    					title: 'XII Milla Urbana y X Legua popular "Alameda de Cervera"',
+    					time: '10:00',
+    					description:
+    						'Categorías Milla Urbana: Benjamín, Alevín, Infantil, Cadete, Junior, Absoluta y Veteranos. <br/><br/>Categorías Legua Pedrestre: Cadete, Junior, Absoluta y Veteranos.<br/><br/> Inscripción gratuita para Benjamín, Alevín e Infantil. 2 € para el resto de categorías de la Milla y 3 € para la Legua.',
+    					location: 'Calle Cervantes',
+    					map: 'https://maps.app.goo.gl/JDWn5PFm6c8vc2mdA',
+    					image:
+    						'https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif'
+    				},
+    					{
+    					title: 'Exposición Hadmaid (Bisutería y arreglos rosas eternas)',
+    					description:
+    						'Días 9 y 10 de 12:00 a 14:00 y de 18:00 a 20:00',
+    					time: '12:00',
+    					location: 'Centro Social'
+    				},
+    				{
+    					title: 'Fiesta de la Espuma infantil',
+    					time: '12:30',
+    					location: 'Parque D. Ramón Fernández Urrutia',
+    					map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7'
+    				},
+    				{
+    					title: 'Subasta en honor al patrón',
+    					time: '22:30',
+    					location: 'Exterior de la Parroquia de San Lorenzo',
+    					map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+    				},
+    				{
+    					title: 'Fuegos artificiales',
+    					time: '00:00',
+    					location: 'Cooperativa San Lorenzo',
+    					map: 'https://maps.app.goo.gl/JwvFF2HDJJN1D6tB7'
+    				},
+    				{
+    					title: 'Pregón a cargo de Bernardo Sevillano Martín',
+    					time: '00:30',
+    					location: 'Corral del Ayuntamiento',
+    					map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA',
+    					description: 'Doctor en Historia por la UCLM con su tesis "El canal del gran priorato (1782-1811)"'
+    				},
+    				{
+    					title: 'Verbena a cargo del grupo "Trópico Show"',
+    					time: 'A continuación',
+    					location: 'Corral del Ayuntamiento',
+    					map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+    				}
+    			]
+    		},
+    		{
+    			title: 'Lunes 10 de agosto de 2026',
+    			event: [
+    				{
+    					title: 'Función religiosa en honor al Santo Patrón',
+    					time: '12:30',
+    					location: 'Parroquia de San Lorenzo',
+    					map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+    				},
+    				{
+    					title: 'Suelta de vaquillas',
+    					time: '18:00',
+    					location: 'Corral del Ayuntamiento',
+    					map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+    				},
+    				{
+    					title: 'Procesión en honor a San Lorenzo',
+    					time: '21:30',
+    					location: 'Parroquia de San Lorenzo',
+    					map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+    				},
+    				{
+    					title: 'Verbena a cargo del grupo "Caribe Show"',
+    					time: '23:30',
+    					location: 'Corral del Ayuntamiento',
+    					map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+    				}
+    			]
+    		},
+    		{
+    			title: 'Martes 11 de agosto de 2026',
+    			event: [
+    				{
+    					title: 'Misa de difuntos',
+    					time: '11:00',
+    					location: 'Parroquia de San Lorenzo',
+    					map: 'https://maps.app.goo.gl/ts677RMoRGR2qwhHA'
+    				},
+    				{
+    					title: 'Cata de vinos',
+    					time: '12:00',
+    					location: 'Salón de Actos',
+    					map: 'https://maps.app.goo.gl/vGopz6osdKnU1U7u9'
+    				},
+    				{
+    					title: 'Comida de hermandad',
+    					time: '15:00',
+    					location: 'Parque D. Ramón Fernández Urrutia',
+    					description: 'A 2,50 €/ración',
+    					map: 'https://maps.app.goo.gl/FW3cu4Uj98WVMRcQ7'
+    				},
+    				{
+    					title: 'DJ de Alcázar de San Juan',
+    					time: '23:00',
+    					location: 'Corral del Ayuntamiento',
+    					map: 'https://maps.app.goo.gl/yoYbRTWXKwsy6TeBA'
+    				}
+    			]
+    		}
+    	]
+    }}
+
 />


### PR DESCRIPTION
Cambia la fecha del II Torneo de Pádel Infantil San Lorenzo del 8 de agosto al 4 de agosto en el programa de fiestas de 2026.

### Cambios realizados:
- Crea un nuevo evento el miércoles 4 de agosto para el pádel infantil
- Reordena los eventos para mantener la cronología correcta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas funciones**
  * Añadido el programa completo de las fiestas de San Lorenzo 2026.
  * Incluye actividades deportivas, religiosas, culturales y musicales del 1 al 11 de agosto.
  * Se muestran horarios, ubicaciones, descripciones, mapas e imágenes cuando están disponibles.
  * Incorporada información sobre inscripciones y precios para determinadas actividades.
  * El calendario facilita la consulta de todos los eventos y sus detalles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->