### PR TITLE
Añade entrada de blog: XI Milla Urbana y IX Legua Pedrestre 2026

### DIFF
--- a/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
+++ b/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
@@ -1,14 +1,14 @@
 ---
 title: 'XI Milla Urbana y IX Legua Pedrestre'
 description: 'Nueva edición de la Milla Urbana y la Legua Pedrestre en Alameda de Cervera'
-date: '15 Jul 2026'
-pubDate: '2026-07-15'
-image: '/images/news/milla-urbana-legua-pedrestre-2025.webp'
+date: '27 Jul 2026'
+pubDate: '2026-07-27'
+image: 'https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif'
 ---
 
 import FontBold from '@components/FontBold.astro'
 
-Un año más, tendrá lugar una nueva edición, la undécima, de la Milla Urbana y la novena de la Legua Pedrestre en Alameda de Cervera. El evento deportivo se llevará a cabo el próximo <span style="color:red">domingo [FECHA PENDIENTE] de agosto a las 10:00 horas</span>. Organizado por CA Sistemas y el Instituto Municipal de Deportes, con la colaboración del Ayuntamiento de Alcázar de San Juan, Cruz Roja, Protección Civil de Alcázar de San Juan y la Asociación de Vecinos de Alameda de Cervera.
+Un año más, tendrá lugar una nueva edición, la undécima, de la Milla Urbana y la novena de la Legua Pedrestre en Alameda de Cervera. El evento deportivo se llevará a cabo el próximo domingo 9 de agosto a las 10:00 horas. Organizado por el Instituto Municipal de Deportes, con la colaboración del Ayuntamiento de Alcázar de San Juan, Cruz Roja y Protección Civil de Alcázar de San Juan.
 
 Las distintas categorías y sus respectivas distancias para la XI Milla Urbana serán las siguientes:
 
@@ -32,52 +32,13 @@ Para la IX Legua Pedestre, las categorías y distancias serán las siguientes:
 
 Se otorgarán trofeos a los tres primeros clasificados masculinos y femeninos en las categoría general, de la Milla Urbana, así como a los tres primeros clasificados masculinos y femeninos en la categoría general de la Legua.
 
-Para aquellos interesados en participar, el precio de inscripción será gratuito para las categorías Benjamín, Alevín e Infantil, y 3 € para el resto de categorías de la Milla. La inscripción para Milla+Legua tendrá un coste de 8 € para todas las categorías.
+Para aquellos interesados en participar, el precio de inscripción será gratuito para las categorías Benjamín, Alevín e Infantil, y 2 € para el resto de categorías de la Milla. La inscripción para la Legua tendrá un coste de 3 €.
 
-Para formalizar la inscripción, los interesados podrán enviar un correo electrónico a <FontBold className="text-secondary"><a href='mailto:carlosangel1972@hotmail.com'>carlosangel1972@hotmail.com</a></FontBold> indicando nombre, apellidos y fecha de nacimiento. También habrá opción de inscribirse de forma presencial hasta 15 minutos antes del inicio de la salida de cada categoría.
+Para formalizar la inscripción, los interesados podrán enviar un correo electrónico a <FontBold className="text-secondary"><a href='mailto:carlosangel1972@hotmail.com'>carlosangel1972@hotmail.com</a></FontBold>. También habrá opción de inscribirse de forma presencial hasta 15 minutos antes del inicio de la salida de cada categoría.
 
-{' '}
-
-<p style='color:red; text-align:center'>
-	[IMAGEN PENDIENTE: sustituir por el cartel/foto principal 2026 - se muestra la de 2025]
-</p>
 
 <figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
-	<a
-		href='/images/news/milla-urbana-legua-pedrestre-2025.webp'
-		target='_blank'
-		rel='noopener noreferrer'
-	>
-		<img
-			src='/images/news/milla-urbana-legua-pedrestre-2025.webp'
-			alt='cartel-carrera'
-			class='rounded max-w-auto mt-14'
-		/>
-	</a>
-</figure>
-
-<p style='color:red; text-align:center'>
-	[IMAGEN PENDIENTE: sustituir por el cartel oficial XI Milla Urbana 2026 - se muestra el de la X
-	edición]
-</p>
-
-<figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
-	<a href='/images/news/x-milla-urbana.webp' target='_blank' rel='noopener noreferrer'>
-		<img
-			src='/images/news/x-milla-urbana.webp'
-			alt='cartel-carrera'
-			class='rounded max-w-auto mt-14'
-		/>
-	</a>
-</figure>
-
-<p style='color:red; text-align:center'>
-	[IMAGEN PENDIENTE: sustituir por el cartel oficial IX Legua Pedestre 2026 - se muestra el de la
-	VIII edición]
-</p>
-
-<figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
-	<a href='/images/news/viii-legua.webp' target='_blank' rel='noopener noreferrer'>
-		<img src='/images/news/viii-legua.webp' alt='cartel-carrera' class='rounded max-w-auto mt-14' />
+	<a href='https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif' target='_blank' rel='noopener noreferrer'>
+		<img src='https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif' alt='cartel-carrera' class='rounded max-w-auto mt-14' />
 	</a>
 </figure>

--- a/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
+++ b/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
@@ -30,7 +30,7 @@ Para la IX Legua Pedestre, las categorías y distancias serán las siguientes:
 	<li>Cadete, Junior, Absoluta y Veteranos: 4827 m (Legua)</li>
 </ul>
 
-Se otorgarán trofeos a los tres primeros clasificados masculinos y femeninos en las categoría general, de la Milla Urbana, así como a los tres primeros clasificados masculinos y femeninos en la categoría general de la Legua.
+Se otorgarán trofeos a los tres primeros clasificados masculinos y femeninos en la categoría general, de la Milla Urbana, así como a los tres primeros clasificados masculinos y femeninos en la categoría general de la Legua.
 
 Para aquellos interesados en participar, el precio de inscripción será gratuito para las categorías Benjamín, Alevín e Infantil, y 2 € para el resto de categorías de la Milla. La inscripción para la Legua tendrá un coste de 3 €.
 

--- a/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
+++ b/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
@@ -42,3 +42,4 @@ Para formalizar la inscripción, los interesados podrán enviar un correo electr
 		<img src='https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785138323390_hebpbf.avif' alt='cartel-carrera' class='rounded max-w-auto mt-14' />
 	</a>
 </figure>
+

--- a/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
+++ b/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
@@ -8,7 +8,7 @@ image: 'https://res.cloudinary.com/daid7iwrd/image/upload/v1785138697/img_1_1785
 
 import FontBold from '@components/FontBold.astro'
 
-Un año más, tendrá lugar una nueva edición, la undécima, de la Milla Urbana y la novena de la Legua Pedrestre en Alameda de Cervera. El evento deportivo se llevará a cabo el próximo domingo 9 de agosto a las 10:00 horas. Organizado por el Instituto Municipal de Deportes, con la colaboración del Ayuntamiento de Alcázar de San Juan, Cruz Roja y Protección Civil de Alcázar de San Juan.
+Un año más, tendrá lugar una nueva edición, la undécima, de la Milla Urbana y la novena de la Legua Pedrestre en Alameda de Cervera. El evento deportivo se llevará a cabo el domingo 9 de agosto a las 10:00 horas. Organizado por el Instituto Municipal de Deportes, con la colaboración del Ayuntamiento de Alcázar de San Juan, Cruz Roja y Protección Civil de Alcázar de San Juan.
 
 Las distintas categorías y sus respectivas distancias para la XI Milla Urbana serán las siguientes:
 

--- a/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
+++ b/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
@@ -38,7 +38,9 @@ Para formalizar la inscripción, los interesados podrán enviar un correo electr
 
 {' '}
 
-<p style="color:red; text-align:center">[IMAGEN PENDIENTE: sustituir por el cartel/foto principal 2026 - se muestra la de 2025]</p>
+<p style='color:red; text-align:center'>
+	[IMAGEN PENDIENTE: sustituir por el cartel/foto principal 2026 - se muestra la de 2025]
+</p>
 
 <figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
 	<a
@@ -54,7 +56,10 @@ Para formalizar la inscripción, los interesados podrán enviar un correo electr
 	</a>
 </figure>
 
-<p style="color:red; text-align:center">[IMAGEN PENDIENTE: sustituir por el cartel oficial XI Milla Urbana 2026 - se muestra el de la X edición]</p>
+<p style='color:red; text-align:center'>
+	[IMAGEN PENDIENTE: sustituir por el cartel oficial XI Milla Urbana 2026 - se muestra el de la X
+	edición]
+</p>
 
 <figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
 	<a href='/images/news/x-milla-urbana.webp' target='_blank' rel='noopener noreferrer'>
@@ -66,7 +71,10 @@ Para formalizar la inscripción, los interesados podrán enviar un correo electr
 	</a>
 </figure>
 
-<p style="color:red; text-align:center">[IMAGEN PENDIENTE: sustituir por el cartel oficial IX Legua Pedestre 2026 - se muestra el de la VIII edición]</p>
+<p style='color:red; text-align:center'>
+	[IMAGEN PENDIENTE: sustituir por el cartel oficial IX Legua Pedestre 2026 - se muestra el de la
+	VIII edición]
+</p>
 
 <figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
 	<a href='/images/news/viii-legua.webp' target='_blank' rel='noopener noreferrer'>

--- a/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
+++ b/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
@@ -1,0 +1,75 @@
+---
+title: 'XI Milla Urbana y IX Legua Pedrestre'
+description: 'Nueva edición de la Milla Urbana y la Legua Pedrestre en Alameda de Cervera'
+date: '15 Jul 2026'
+pubDate: '2026-07-15'
+image: '/images/news/milla-urbana-legua-pedrestre-2025.webp'
+---
+
+import FontBold from '@components/FontBold.astro'
+
+Un año más, tendrá lugar una nueva edición, la undécima, de la Milla Urbana y la novena de la Legua Pedrestre en Alameda de Cervera. El evento deportivo se llevará a cabo el próximo <span style="color:red">domingo [FECHA PENDIENTE] de agosto a las 10:00 horas</span>. Organizado por CA Sistemas y el Instituto Municipal de Deportes, con la colaboración del Ayuntamiento de Alcázar de San Juan, Cruz Roja, Protección Civil de Alcázar de San Juan y la Asociación de Vecinos de Alameda de Cervera.
+
+Las distintas categorías y sus respectivas distancias para la XI Milla Urbana serán las siguientes:
+
+{' '}
+
+<ul class='px-5 space-y-1 list-disc list-inside'>
+	<li>Benjamín: 536 m (1 vuelta circuito Milla)</li>
+	<li>Alevín: 536 m (1 vuelta circuito Milla)</li>
+	<li>Infantil: 1072 m (2 vueltas circuito Milla)</li>
+	<li>Cadete: 1609 m (3 vueltas circuito Milla)</li>
+	<li>Junior, Absoluta y Veteranos: 1609 m (Milla completa)</li>
+</ul>
+
+Para la IX Legua Pedestre, las categorías y distancias serán las siguientes:
+
+{' '}
+
+<ul class='px-5 space-y-1 list-disc list-inside '>
+	<li>Cadete, Junior, Absoluta y Veteranos: 4827 m (Legua)</li>
+</ul>
+
+Se otorgarán trofeos a los tres primeros clasificados masculinos y femeninos en las categoría general, de la Milla Urbana, así como a los tres primeros clasificados masculinos y femeninos en la categoría general de la Legua.
+
+Para aquellos interesados en participar, el precio de inscripción será gratuito para las categorías Benjamín, Alevín e Infantil, y 3 € para el resto de categorías de la Milla. La inscripción para Milla+Legua tendrá un coste de 8 € para todas las categorías.
+
+Para formalizar la inscripción, los interesados podrán enviar un correo electrónico a <FontBold className="text-secondary"><a href='mailto:carlosangel1972@hotmail.com'>carlosangel1972@hotmail.com</a></FontBold> indicando nombre, apellidos y fecha de nacimiento. También habrá opción de inscribirse de forma presencial hasta 15 minutos antes del inicio de la salida de cada categoría.
+
+{' '}
+
+<p style="color:red; text-align:center">[IMAGEN PENDIENTE: sustituir por el cartel/foto principal 2026 - se muestra la de 2025]</p>
+
+<figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
+	<a
+		href='/images/news/milla-urbana-legua-pedrestre-2025.webp'
+		target='_blank'
+		rel='noopener noreferrer'
+	>
+		<img
+			src='/images/news/milla-urbana-legua-pedrestre-2025.webp'
+			alt='cartel-carrera'
+			class='rounded max-w-auto mt-14'
+		/>
+	</a>
+</figure>
+
+<p style="color:red; text-align:center">[IMAGEN PENDIENTE: sustituir por el cartel oficial XI Milla Urbana 2026 - se muestra el de la X edición]</p>
+
+<figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
+	<a href='/images/news/x-milla-urbana.webp' target='_blank' rel='noopener noreferrer'>
+		<img
+			src='/images/news/x-milla-urbana.webp'
+			alt='cartel-carrera'
+			class='rounded max-w-auto mt-14'
+		/>
+	</a>
+</figure>
+
+<p style="color:red; text-align:center">[IMAGEN PENDIENTE: sustituir por el cartel oficial IX Legua Pedestre 2026 - se muestra el de la VIII edición]</p>
+
+<figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>
+	<a href='/images/news/viii-legua.webp' target='_blank' rel='noopener noreferrer'>
+		<img src='/images/news/viii-legua.webp' alt='cartel-carrera' class='rounded max-w-auto mt-14' />
+	</a>
+</figure>

--- a/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
+++ b/src/content/blog/milla-urbana-legua-pedrestre-2026.mdx
@@ -34,7 +34,7 @@ Se otorgarán trofeos a los tres primeros clasificados masculinos y femeninos en
 
 Para aquellos interesados en participar, el precio de inscripción será gratuito para las categorías Benjamín, Alevín e Infantil, y 2 € para el resto de categorías de la Milla. La inscripción para la Legua tendrá un coste de 3 €.
 
-Para formalizar la inscripción, los interesados podrán enviar un correo electrónico a <FontBold className="text-secondary"><a href='mailto:carlosangel1972@hotmail.com'>carlosangel1972@hotmail.com</a></FontBold>. También habrá opción de inscribirse de forma presencial hasta 15 minutos antes del inicio de la salida de cada categoría.
+Para formalizar la inscripción, los interesados podrán enviar un correo electrónico a <FontBold className='text-secondary'><a href='mailto:carlosangel1972@hotmail.com'>carlosangel1972@hotmail.com</a></FontBold>. También habrá opción de inscribirse de forma presencial hasta 15 minutos antes del inicio de la salida de cada categoría.
 
 
 <figure class='rounded shadow-lg shadow-gray-400 max-w-auto lg:max-w-lg mx-auto'>


### PR DESCRIPTION
## Resumen
Nueva entrada de blog para la XI Milla Urbana y IX Legua Pedrestre 2026, basada en la edición de 2025.

## Pendiente antes de publicar
Se ha marcado **en rojo** en el propio contenido lo que falta por confirmar/actualizar:
- Fecha exacta del evento (domingo de agosto)
- Cartel/foto principal 2026 (se usa temporalmente la imagen de 2025)
- Cartel oficial de la XI Milla Urbana (se usa temporalmente el de la X edición)
- Cartel oficial de la IX Legua Pedestre (se usa temporalmente el de la VIII edición)

En cuanto se disponga de las fechas y carteles definitivos, solo hay que sustituir esos textos/imágenes y quitar el estilo en rojo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Añadida una nueva publicación del blog sobre la XI Milla Urbana y la IX Legua Pedestre de Alameda de Cervera.
  * Incluye información sobre fechas, horarios, categorías, distancias, inscripciones, precios, organizadores y entrega de trofeos.
  * Incorporada una imagen ilustrativa con texto alternativo y enlace accesible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->