### PR TITLE
Añade entrada de blog: XXIII Concurso de Pintura al Aire Libre Gran Prior 2026

### DIFF
--- a/src/content/blog/xxiii-concurso-pintura-aire-libre.mdx
+++ b/src/content/blog/xxiii-concurso-pintura-aire-libre.mdx
@@ -6,7 +6,9 @@ pubDate: '2026-07-10'
 image: '/images/news/xxii-pal.webp'
 ---
 
-<h6 class='text-sm' style="color:red">Actualizado el listado de premios el [FECHA PENDIENTE]/2026</h6>
+<h6 class='text-sm' style='color:red'>
+	Actualizado el listado de premios el [FECHA PENDIENTE]/2026
+</h6>
 
 Un año más, tendrá lugar una nueva edición, la vigésimo segunda, del Concurso de Pintura al Aire Libre "Gran Prior". El concurso se llevará a cabo el próximo <span style="color:red">[FECHA PENDIENTE] de agosto</span> en Alameda de Cervera y alrededores. Este concurso, celebrado durante las fiestas de San Lorenzo, invita a artistas a capturar la esencia del paisaje y la vida rural del pueblo.
 
@@ -42,14 +44,16 @@ El concurso será el día <span style="color:red">**[FECHA PENDIENTE] de agosto*
 	<li>
 		**Tablilla**: Lado mayor no exceda de 21 cm. y el menor no sea inferior a 10 cm. Es una
 		sugerencia cuya decisión es del pintor y se aceptarán otras medidas, siempre y cuando así lo
-		comuniquen los autores. Precio para las "tablillas" <span style="color:red">[PRECIO PENDIENTE]€</span>. Se pueden presentar cuantas tablillas
-		se sellen.
+		comuniquen los autores. Precio para las "tablillas"{' '}
+		<span style='color:red'>[PRECIO PENDIENTE]€</span>. Se pueden presentar cuantas tablillas se
+		sellen.
 	</li>
 	<li>
 		**Miniatura**: Lado mayor y menor no exceda de 10 cm. A partir de ahí cada cual es libre de dar
-		el tamaño y proporción que desee. Precio por miniatura <span style="color:red">[PRECIO PENDIENTE]€</span>. Se pueden presentar cuantas
-		miniaturas se sellen. Las miniaturas se podrán adquirir a pie de calle, si el pintor lo permite.
-		Esta categoría no entra dentro del concurso a obtener premio.
+		el tamaño y proporción que desee. Precio por miniatura{' '}
+		<span style='color:red'>[PRECIO PENDIENTE]€</span>. Se pueden presentar cuantas miniaturas se
+		sellen. Las miniaturas se podrán adquirir a pie de calle, si el pintor lo permite. Esta
+		categoría no entra dentro del concurso a obtener premio.
 	</li>
 </ul>
 
@@ -57,11 +61,12 @@ El concurso será el día <span style="color:red">**[FECHA PENDIENTE] de agosto*
 <li>**Las obras deben ser identificables con el entorno paisajístico, urbano y monumental de Alameda de Cervera**. Facilitando a los diferentes participantes, ubicaciones de los lugares o parajes emblemáticos de la zona de Alameda, los cuales son: Puente Gran Prior, Puente Vado Lancero, Castillo de Cervera (conocido como la casa grande), Villacentenos, Cooperativa, Parroquia de San Lorenzo, entre otros entornos y campos de la pedanía.</li>
 
 <li>
-	Hora y lugar de **sellado de las superficies: A partir de las 9:00 de la mañana el día <span style="color:red">[FECHA PENDIENTE] de
-	agosto</span>**, en el salón de actos, junto al parque, D. Juan de Villanueva y Bar José Ángel. Se pueden
-	sellar todas las superficies deseadas, finalizando el sellado a las 15:00. En ningún caso se
-	sellará una superficie ya pintada o parcialmente pintada. Sello e inscripción se debe realizar
-	antes de comenzar a pintar. Se pueden sellar cuantas superficies se deseen.
+	Hora y lugar de **sellado de las superficies: A partir de las 9:00 de la mañana el día{' '}
+	<span style='color:red'>[FECHA PENDIENTE] de agosto</span>**, en el salón de actos, junto al
+	parque, D. Juan de Villanueva y Bar José Ángel. Se pueden sellar todas las superficies deseadas,
+	finalizando el sellado a las 15:00. En ningún caso se sellará una superficie ya pintada o
+	parcialmente pintada. Sello e inscripción se debe realizar antes de comenzar a pintar. Se pueden
+	sellar cuantas superficies se deseen.
 </li>
 
 <li>Hora y lugar de entrega de las obras: Salón de Actos a partir de las 19:00 hasta las 19:15.</li>
@@ -78,9 +83,12 @@ El concurso será el día <span style="color:red">**[FECHA PENDIENTE] de agosto*
     <h3 class='text-xl font-semibold underline' style="color:red">Listado de premios (Actualizado [FECHA PENDIENTE]/2026)</h3>
     <h4 class='text-lg font-medium'>Bloque de cuadros</h4>
 
-<p style="color:red">[PENDIENTE: actualizar patrocinadores/importes 2026 - se muestra el listado de la XXII edición como referencia]</p>
+<p style='color:red'>
+	[PENDIENTE: actualizar patrocinadores/importes 2026 - se muestra el listado de la XXII edición
+	como referencia]
+</p>
 
-<ul class='flex flex-col space-y-4 list-disc ml-8' style="color:red">
+<ul class='flex flex-col space-y-4 list-disc ml-8' style='color:red'>
 	<li>**400€** -- Piscina Alameda</li>
 	<li>**350€** -- Grupo de Integración Almida</li>
 	<li>**300€** -- Disfran Moreno</li>
@@ -95,16 +103,33 @@ El concurso será el día <span style="color:red">**[FECHA PENDIENTE] de agosto*
 
 <h4 class='text-lg font-medium'>Bloque de tablillas</h4>
 
-<p style="color:red">[PENDIENTE: actualizar patrocinadores 2026 - importe confirmado 60€ - se muestra el listado de la XXII edición como referencia]</p>
+<p style='color:red'>
+	[PENDIENTE: actualizar patrocinadores 2026 - importe confirmado 60€ - se muestra el listado de la
+	XXII edición como referencia]
+</p>
 
 <ul class='flex flex-col space-y-4 list-disc ml-8'>
-	<li>**60€** -- <span style="color:red">Gran Prior</span></li>
-	<li>**60€** -- <span style="color:red">Enrique Lubián</span></li>
-	<li>**60€** -- <span style="color:red">Las Corbeteras</span></li>
-	<li>**60€** -- <span style="color:red">Instalaciones Eléctricas Jimenez Castellanos, S.L.</span></li>
-	<li>**60€** -- <span style="color:red">EVR MOTORSPORT</span></li>
-	<li>**60€** -- <span style="color:red">Las Musas</span></li>
-	<li>**60€** -- <span style="color:red">Rubio C.B.</span></li>
+	<li>
+		**60€** -- <span style='color:red'>Gran Prior</span>
+	</li>
+	<li>
+		**60€** -- <span style='color:red'>Enrique Lubián</span>
+	</li>
+	<li>
+		**60€** -- <span style='color:red'>Las Corbeteras</span>
+	</li>
+	<li>
+		**60€** -- <span style='color:red'>Instalaciones Eléctricas Jimenez Castellanos, S.L.</span>
+	</li>
+	<li>
+		**60€** -- <span style='color:red'>EVR MOTORSPORT</span>
+	</li>
+	<li>
+		**60€** -- <span style='color:red'>Las Musas</span>
+	</li>
+	<li>
+		**60€** -- <span style='color:red'>Rubio C.B.</span>
+	</li>
 </ul>
 
     **El listado de premios continúa abierto hasta el mismo día del concurso**, pero una vez publicados los premios a otorgar este año, un nuevo patrocinador/colaborador no podrá superar el importe del primer premio.
@@ -155,7 +180,10 @@ PD. Cualquier duda, omisión en las bases u otras serán aclaradas y resueltas e
 
 Agradecer un año más a todos los colaboradores y patrocinadores que hacen posible el desarrollo de esta actividad en las fiestas de la pedanía en honor a San Lorenzo.
 
-<p style="color:red; text-align:center">[IMAGEN PENDIENTE: sustituir por el cartel oficial XXIII edición 2026 - se muestra el de la XXII edición]</p>
+<p style='color:red; text-align:center'>
+	[IMAGEN PENDIENTE: sustituir por el cartel oficial XXIII edición 2026 - se muestra el de la XXII
+	edición]
+</p>
 
 <figure class='rounded shadow-lg shadow-gray-400 bg-gray-800 max-w-md mx-auto'>
 	<a href='/images/news/xxii-pal.webp' target='_blank' rel='noopener noreferrer'>

--- a/src/content/blog/xxiii-concurso-pintura-aire-libre.mdx
+++ b/src/content/blog/xxiii-concurso-pintura-aire-libre.mdx
@@ -1,0 +1,145 @@
+---
+title: 'XXIII Concurso PAL Gran Prior'
+description: 'XXIII Concurso de pintura al aire libre Gran Prior de Alameda de Cervera'
+date: '10 Jul 2026'
+pubDate: '2026-07-10'
+image: '/images/news/xxii-pal.webp'
+---
+
+<h6 class='text-sm' style="color:red">Actualizado el listado de premios el [FECHA PENDIENTE]/2026</h6>
+
+Un año más, tendrá lugar una nueva edición, la vigésimo segunda, del Concurso de Pintura al Aire Libre "Gran Prior". El concurso se llevará a cabo el próximo <span style="color:red">[FECHA PENDIENTE] de agosto</span> en Alameda de Cervera y alrededores. Este concurso, celebrado durante las fiestas de San Lorenzo, invita a artistas a capturar la esencia del paisaje y la vida rural del pueblo.
+
+<h2 class='text-xl font-semibold title-font text-gray-800 pl-5 text-center'>
+	Bases del concurso "XXIII CONCURSO DE PINTURA AL AIRE LIBRE GRAN PRIOR"
+</h2>
+
+En ALAMEDA DE CERVERA año 2026,
+Los promotores (abajo firmantes) junto con los patrocinadores y diversos ciudadanos de Alameda de Cervera convocan un año más el
+“XXIII CONCURSO DE PINTURA AL AIRE LIBRE 'GRAN PRIOR'".
+
+El concurso será el día <span style="color:red">**[FECHA PENDIENTE] de agosto** (sábado)</span> en la pedanía de **Alameda de Cervera**, situada en Autovía de los viñedos, a medio camino entre Alcázar de San Juan y Tomelloso.
+
+<ul class='flex flex-col space-y-4 md:space-y-8 list-disc ml-8'>
+<li class='space-y-4'> 
+<p>**Se pueden presentar a sellar cuantas superficies se deseen**. Tamaño y técnica libre. Opción "lienzos", "tablilla" y "miniatura"</p>
+
+<p>
+	El motivo principal de la pintura es al aire libre es que se pinta a la luz del día en sus
+	diferentes fases, como la mañana, medio día, tarde o atardecer, como excepción de estos años y
+	este no iba a ser menos, se permite pintar la noche, habiéndose dado lugar a que en otras
+	ocasiones ha habido pintores que han pasado por la pedanía de noche y han fotografiado la misma,
+	presentando en varias ediciones que se buscaba el atardecer y la noche estas obras. Por ello este
+	año seguimos manteniendo abierto el abanico a presentar este tipo de obras, así como imágenes de
+	interiores de viviendas o sitios representativos, a demás de ser necesario que sea claramente
+	reconocible la relación de la obra con la pedanía en la que se desarrolla el concurso.
+</p>
+
+<h3 class='text-xl font-semibold'>"Sugerencias" para las diferentes modalidades:</h3>
+
+<ul class='flex flex-col space-y-4 list-disc ml-8'>
+	<li>**Cuadro**: Cualquier tamaño. Es aconsejable lados rectos.</li>
+	<li>
+		**Tablilla**: Lado mayor no exceda de 21 cm. y el menor no sea inferior a 10 cm. Es una
+		sugerencia cuya decisión es del pintor y se aceptarán otras medidas, siempre y cuando así lo
+		comuniquen los autores. Precio para las "tablillas" <span style="color:red">[PRECIO PENDIENTE]€</span>. Se pueden presentar cuantas tablillas
+		se sellen.
+	</li>
+	<li>
+		**Miniatura**: Lado mayor y menor no exceda de 10 cm. A partir de ahí cada cual es libre de dar
+		el tamaño y proporción que desee. Precio por miniatura <span style="color:red">[PRECIO PENDIENTE]€</span>. Se pueden presentar cuantas
+		miniaturas se sellen. Las miniaturas se podrán adquirir a pie de calle, si el pintor lo permite.
+		Esta categoría no entra dentro del concurso a obtener premio.
+	</li>
+</ul>
+
+</li>
+<li>**Las obras deben ser identificables con el entorno paisajístico, urbano y monumental de Alameda de Cervera**. Facilitando a los diferentes participantes, ubicaciones de los lugares o parajes emblemáticos de la zona de Alameda, los cuales son: Puente Gran Prior, Puente Vado Lancero, Castillo de Cervera (conocido como la casa grande), Villacentenos, Cooperativa, Parroquia de San Lorenzo, entre otros entornos y campos de la pedanía.</li>
+
+<li>
+	Hora y lugar de **sellado de las superficies: A partir de las 9:00 de la mañana el día <span style="color:red">[FECHA PENDIENTE] de
+	agosto</span>**, en el salón de actos, junto al parque, D. Juan de Villanueva y Bar José Ángel. Se pueden
+	sellar todas las superficies deseadas, finalizando el sellado a las 15:00. En ningún caso se
+	sellará una superficie ya pintada o parcialmente pintada. Sello e inscripción se debe realizar
+	antes de comenzar a pintar. Se pueden sellar cuantas superficies se deseen.
+</li>
+
+<li>Hora y lugar de entrega de las obras: Salón de Actos a partir de las 19:00 hasta las 19:15.</li>
+
+<li class='space-y-4'>
+	Inmediatamente se procederá a elegir las obras para cada uno de los premios, a puerta abierta. No
+	hay jurado. Por riguroso orden cada patrocinador va eligiendo/adjudicando su premio. El orden de
+	elección de las obras, está sujeto al importe del premio. En caso de varios premios con el mismo
+	importe, se respetará el orden de inscripción y antigüedad de los patrocinadores.
+
+    Los premios pueden quedar desiertos (aunque nunca ha ocurrido) como también pueden ser rechazados
+    por el autor (tampoco ha ocurrido).
+
+    <h3 class='text-xl font-semibold underline' style="color:red">Listado de premios (Actualizado [FECHA PENDIENTE]/2026)</h3>
+    <h4 class='text-lg font-medium'>Bloque de cuadros</h4>
+
+<ul class='flex flex-col space-y-4 list-disc ml-8' style="color:red">
+	<li>[LISTADO DE PREMIOS PENDIENTE DE ACTUALIZAR PARA 2026]</li>
+</ul>
+
+<h4 class='text-lg font-medium'>Bloque de tablillas</h4>
+
+<ul class='flex flex-col space-y-4 list-disc ml-8' style="color:red">
+	<li>[LISTADO DE PREMIOS PENDIENTE DE ACTUALIZAR PARA 2026]</li>
+</ul>
+
+    **El listado de premios continúa abierto hasta el mismo día del concurso**, pero una vez publicados los premios a otorgar este año, un nuevo patrocinador/colaborador no podrá superar el importe del primer premio.
+
+</li>
+
+<li class='list-none'>
+	Las pinturas premiadas pasarán a ser propiedad de la entidad que otorga el premio.
+</li>
+<li class='list-none'>
+	Los participantes deben ir provistos de todo el material que puedan necesitar para la realización
+	de su obra. Será necesario el uso del caballete de cada artista para la exposición de los cuadros
+	realizados.
+</li>
+
+<li>
+	Tras la entrega de premios se procederá a la compra, por parte del público asistente, de las obras
+	restantes. Cada pintor se colocará en una mesa con su producción de tablillas y miniaturas. Para
+	evitar en lo posible aglomeraciones y poder realizar una visión y adquisición de las obras más
+	fluida.
+</li>
+
+<li>
+	Cada concursante se presenta a esta convocatoria libremente y bajo su estricta responsabilidad y
+	cargos.
+</li>
+
+</ul>
+
+_NOTA: Las obras deben ser perfectamente identificables con el entorno paisajístico y urbano de Alameda de Cervera._
+
+PD. Cualquier duda, omisión en las bases u otras serán aclaradas y resueltas en el momento de su planteamiento:
+
+<ul class='flex flex-col list-disc ml-8'>
+	<li class='break-before-auto'>
+		<strong class='mr-2'>Ana Sánchez-Mateos Lizcano</strong> <a href='tel:649278795'>649278795</a>{' '}
+		<a href='mailto:ana.sanchezmateos@gmail.com'>ana.sanchezmateos@gmail.com</a>
+	</li>
+	<li>
+		<strong class='mr-2'>Inmaculada Rubio Octavio</strong> <a href='tel:660303078'>660303078</a>{' '}
+		<a href='mailto:inmavera12@hotmail.com'>inmavera12@hotmail.com</a>
+	</li>
+	<li>
+		<strong class='mr-2'>Asociación de Vecinos de Alameda de Cervera</strong>{' '}
+		<a href='mailto:vecinosalamedadecervera@gmail.com'>vecinosalamedadecervera@gmail.com</a>
+	</li>
+</ul>
+
+Agradecer un año más a todos los colaboradores y patrocinadores que hacen posible el desarrollo de esta actividad en las fiestas de la pedanía en honor a San Lorenzo.
+
+<p style="color:red; text-align:center">[IMAGEN PENDIENTE: sustituir por el cartel oficial XXIII edición 2026 - se muestra el de la XXII edición]</p>
+
+<figure class='rounded shadow-lg shadow-gray-400 bg-gray-800 max-w-md mx-auto'>
+	<a href='/images/news/xxii-pal.webp' target='_blank' rel='noopener noreferrer'>
+		<img src='/images/news/xxii-pal.webp' alt='cartel-xxii-pal' class='rounded max-w-auto mt-14' />
+	</a>
+</figure>

--- a/src/content/blog/xxiii-concurso-pintura-aire-libre.mdx
+++ b/src/content/blog/xxiii-concurso-pintura-aire-libre.mdx
@@ -95,16 +95,16 @@ El concurso será el día <span style="color:red">**[FECHA PENDIENTE] de agosto*
 
 <h4 class='text-lg font-medium'>Bloque de tablillas</h4>
 
-<p style="color:red">[PENDIENTE: actualizar patrocinadores/importes 2026 - se muestra el listado de la XXII edición como referencia]</p>
+<p style="color:red">[PENDIENTE: actualizar patrocinadores 2026 - importe confirmado 60€ - se muestra el listado de la XXII edición como referencia]</p>
 
-<ul class='flex flex-col space-y-4 list-disc ml-8' style="color:red">
-	<li>**60€** -- Gran Prior</li>
-	<li>**60€** -- Enrique Lubián</li>
-	<li>**60€** -- Las Corbeteras</li>
-	<li>**60€** -- Instalaciones Eléctricas Jimenez Castellanos, S.L. </li>
-	<li>**60€** -- EVR MOTORSPORT</li>
-	<li>**60€** -- Las Musas</li>
-	<li>**60€** -- Rubio C.B.</li>
+<ul class='flex flex-col space-y-4 list-disc ml-8'>
+	<li>**60€** -- <span style="color:red">Gran Prior</span></li>
+	<li>**60€** -- <span style="color:red">Enrique Lubián</span></li>
+	<li>**60€** -- <span style="color:red">Las Corbeteras</span></li>
+	<li>**60€** -- <span style="color:red">Instalaciones Eléctricas Jimenez Castellanos, S.L.</span></li>
+	<li>**60€** -- <span style="color:red">EVR MOTORSPORT</span></li>
+	<li>**60€** -- <span style="color:red">Las Musas</span></li>
+	<li>**60€** -- <span style="color:red">Rubio C.B.</span></li>
 </ul>
 
     **El listado de premios continúa abierto hasta el mismo día del concurso**, pero una vez publicados los premios a otorgar este año, un nuevo patrocinador/colaborador no podrá superar el importe del primer premio.

--- a/src/content/blog/xxiii-concurso-pintura-aire-libre.mdx
+++ b/src/content/blog/xxiii-concurso-pintura-aire-libre.mdx
@@ -78,14 +78,33 @@ El concurso será el día <span style="color:red">**[FECHA PENDIENTE] de agosto*
     <h3 class='text-xl font-semibold underline' style="color:red">Listado de premios (Actualizado [FECHA PENDIENTE]/2026)</h3>
     <h4 class='text-lg font-medium'>Bloque de cuadros</h4>
 
+<p style="color:red">[PENDIENTE: actualizar patrocinadores/importes 2026 - se muestra el listado de la XXII edición como referencia]</p>
+
 <ul class='flex flex-col space-y-4 list-disc ml-8' style="color:red">
-	<li>[LISTADO DE PREMIOS PENDIENTE DE ACTUALIZAR PARA 2026]</li>
+	<li>**400€** -- Piscina Alameda</li>
+	<li>**350€** -- Grupo de Integración Almida</li>
+	<li>**300€** -- Disfran Moreno</li>
+	<li>**300€** -- Bodega Los 3 Caños</li>
+	<li>**250€ y 2 Estuches de vino** -- Cooperativa San Lorenzo</li>
+	<li>**250€** -- Bar José Angel</li>
+	<li>**200€** -- Tarimas y Parquets Esteban Izquierdo</li>
+	<li>**150€** -- Pinturas Juan Vela</li>
+	<li>**150€** -- AgroPanadero S.L.</li>
+	<li>**150€** -- Los Tardíos Viejos</li>
 </ul>
 
 <h4 class='text-lg font-medium'>Bloque de tablillas</h4>
 
+<p style="color:red">[PENDIENTE: actualizar patrocinadores/importes 2026 - se muestra el listado de la XXII edición como referencia]</p>
+
 <ul class='flex flex-col space-y-4 list-disc ml-8' style="color:red">
-	<li>[LISTADO DE PREMIOS PENDIENTE DE ACTUALIZAR PARA 2026]</li>
+	<li>**60€** -- Gran Prior</li>
+	<li>**60€** -- Enrique Lubián</li>
+	<li>**60€** -- Las Corbeteras</li>
+	<li>**60€** -- Instalaciones Eléctricas Jimenez Castellanos, S.L. </li>
+	<li>**60€** -- EVR MOTORSPORT</li>
+	<li>**60€** -- Las Musas</li>
+	<li>**60€** -- Rubio C.B.</li>
 </ul>
 
     **El listado de premios continúa abierto hasta el mismo día del concurso**, pero una vez publicados los premios a otorgar este año, un nuevo patrocinador/colaborador no podrá superar el importe del primer premio.


### PR DESCRIPTION
## Resumen
Nueva entrada de blog para la XXIII edición del Concurso de Pintura al Aire Libre "Gran Prior" 2026, basada en la edición XXII (2025).

## Pendiente antes de publicar
Marcado **en rojo** en el propio contenido lo que falta por confirmar/actualizar:
- Fecha del concurso (día de agosto, sábado)
- Fecha de actualización del listado de premios
- Precios de tablilla y miniatura (por si cambian)
- Listado completo de premios y patrocinadores 2026
- Cartel oficial (se usa temporalmente el de la XXII edición)

En cuanto se disponga de los datos definitivos, solo hay que sustituir esos textos/imagen y quitar el estilo en rojo.